### PR TITLE
Dornerworks x64 VM Patches

### DIFF
--- a/components/Init/src/main.c
+++ b/components/Init/src/main.c
@@ -238,7 +238,7 @@ static memory_range_t guest_fake_devices[] = {
 
 /* Memory areas we reserve for anonymous allocations */
 static memory_range_t free_anonymous_regions[] = {
-    {0x10001000, 0xa0000000 - 0x10001000},
+    {0x10003000, 0xa0000000 - 0x10003000},
 };
 
 typedef struct device_notify {

--- a/components/Init/src/main.c
+++ b/components/Init/src/main.c
@@ -626,8 +626,10 @@ void *main_continued(void *arg)
 
     pci_io_ops = make_pci_io_ops();
 
-    ZF_LOGI("PCI scan");
-    libpci_scan(pci_io_ops);
+    if (pci_devices_num_devices() > 0) {
+        ZF_LOGI("PCI scan");
+        libpci_scan(pci_io_ops);
+    }
 
     /* install custom open/close/read implementations to redirect I/O from the VMM to
      * our file server */


### PR DESCRIPTION
Merge Dornerworks' patches to our repo for development purposes. There is a PR for upstream aswell, but it hasn't been merged yet. See https://github.com/seL4/camkes-vm/pull/7

This PR contains commits from Dornerworks' x64 VM patches for camkes-vm: https://github.com/dornerworks/camkes-vm/tree/open_source_release. Only parts of dornerworks@1cd3916 were taken. The HPET emulation requires slightly more work due to the new refactored VMMs having a different model for memory faults.