### PR TITLE
FDT fix

### DIFF
--- a/arm_vm_helpers.cmake
+++ b/arm_vm_helpers.cmake
@@ -45,10 +45,14 @@ function(DeclareCAmkESARMVM init_component)
         vm_src
         ${ARM_VM_PROJECT_DIR}/components/VM_Arm/src/main.c
         ${ARM_VM_PROJECT_DIR}/components/VM_Arm/src/fdt_manipulation.c
-        ${ARM_VM_PROJECT_DIR}/components/VM_Arm/src/crossvm.c
         ${ARM_VM_PROJECT_DIR}/components/VM_Arm/src/modules/map_frame_hack.c
         ${ARM_VM_PROJECT_DIR}/components/VM_Arm/src/modules/init_ram.c
     )
+
+    if(VmPCISupport)
+        list(APPEND vm_src ${ARM_VM_PROJECT_DIR}/components/VM_Arm/src/crossvm.c)
+        list(APPEND vm_src ${ARM_VM_PROJECT_DIR}/components/VM_Arm/src/modules/pci.c)
+    endif()
 
     if(VmVirtUart)
         list(APPEND vm_src ${ARM_VM_PROJECT_DIR}/components/VM_Arm/src/modules/vuart_init.c)

--- a/components/VM_Arm/include/vmlinux.h
+++ b/components/VM_Arm/include/vmlinux.h
@@ -5,6 +5,7 @@
  */
 #pragma once
 
+#include <arm_vm/gen_config.h>
 #include <sel4utils/irq_server.h>
 #include <sel4vm/guest_vm.h>
 #include <sel4vmmplatsupport/drivers/cross_vm_connection.h>
@@ -16,6 +17,14 @@
 #define MACH_TYPE            MACH_TYPE_SPECIAL
 
 #define FREE_IOPORT_START    0x1000
+
+#ifdef CONFIG_VM_PCI_SUPPORT
+typedef struct vmm_pci_space vmm_pci_space_t;
+typedef struct vmm_io_list vmm_io_port_list_t;
+
+extern vmm_pci_space_t *pci;
+extern vmm_io_port_list_t *io_ports;
+#endif
 
 extern char gen_dtb_buf[];
 extern void *fdt_ori;

--- a/components/VM_Arm/src/crossvm.c
+++ b/components/VM_Arm/src/crossvm.c
@@ -13,8 +13,6 @@
 #include <sel4vmmplatsupport/drivers/cross_vm_connection.h>
 #include <sel4vmmplatsupport/drivers/pci_helper.h>
 
-extern vmm_pci_space_t *pci;
-
 /* Force the _vmm_cross_connector_definition  section to be created even if no modules are defined. */
 static USED SECTION("_vmm_cross_connector_definition") struct {} dummy_module;
 extern camkes_crossvm_connection_t *__start__vmm_cross_connector_definition[];

--- a/components/VM_Arm/src/modules/pci.c
+++ b/components/VM_Arm/src/modules/pci.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2023, Technology Innovation Institute
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+#include <vmlinux.h>
+#include <camkes.h>
+
+#include <sel4vmmplatsupport/ioports.h>
+#include <sel4vmmplatsupport/arch/vpci.h>
+#include <sel4vmmplatsupport/drivers/pci_helper.h>
+
+#include <libfdt.h>
+
+vmm_pci_space_t *pci;
+vmm_io_port_list_t *io_ports;
+
+static void vpci_init(vm_t *vm, void *cookie)
+{
+    int err;
+
+    err = vmm_pci_init(&pci);
+    if (err) {
+        ZF_LOGF("Failed to initialise vmm pci");
+        /* no return */
+    }
+
+    err = vmm_io_port_init(&io_ports, FREE_IOPORT_START);
+    if (err) {
+        ZF_LOGF("Failed to initialise VM ioports");
+        /* no return */
+    }
+}
+
+DEFINE_MODULE(vpci_init, NULL, vpci_init)
+
+static void vpci_register_devices(vm_t *vm, void *cookie)
+{
+}
+
+DEFINE_MODULE(vpci_register_devices, NULL, vpci_register_devices)
+DEFINE_MODULE_DEP(vpci_register_devices, vpci_init)
+
+static void vpci_install(vm_t *vm, void *cookie)
+{
+    int err = vm_install_vpci(vm, io_ports, pci);
+    if (err) {
+        ZF_LOGF("Failed to install VPCI device");
+        /* no return */
+    }
+
+    if (!vm_config.generate_dtb) {
+        return;
+    }
+
+    int gic_offset = fdt_path_offset(fdt_ori, GIC_NODE_PATH);
+    if (gic_offset < 0) {
+        ZF_LOGF("Failed to find gic node from path: %s", GIC_NODE_PATH);
+        /* no return */
+    }
+    int gic_phandle = fdt_get_phandle(fdt_ori, gic_offset);
+    if (0 == gic_phandle) {
+        ZF_LOGF("Failed to find phandle in gic node");
+        /* no return */
+    }
+    err = fdt_generate_vpci_node(vm, pci, gen_dtb_buf, gic_phandle);
+    if (err) {
+        ZF_LOGF("Couldn't generate vPCI interrupt map (%d)", err);
+        /* no return */
+    }
+}
+
+DEFINE_MODULE(vpci_install, NULL, vpci_install)
+DEFINE_MODULE_DEP(vpci_install, vpci_register_devices)

--- a/components/VM_Arm/src/modules/plat/exynos5410/init.c
+++ b/components/VM_Arm/src/modules/plat/exynos5410/init.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #include <autoconf.h>
-#include <arm_vm/gen_config.h>
 
 #include <vmlinux.h>
 

--- a/components/VM_Arm/src/modules/plat/tk1/init.c
+++ b/components/VM_Arm/src/modules/plat/tk1/init.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #include <autoconf.h>
-#include <arm_vm/gen_config.h>
 
 #include <vmlinux.h>
 

--- a/components/VM_Arm/src/modules/virtio_con.c
+++ b/components/VM_Arm/src/modules/virtio_con.c
@@ -49,8 +49,6 @@
 #define NUM_PORTS (ARRAY_SIZE(serial_layout) + 1)
 
 static virtio_con_t *virtio_con = NULL;
-extern vmm_pci_space_t *pci;
-extern vmm_io_port_list_t *io_ports;
 
 /* 4088 because the serial_shmem_t struct has to be 0x1000 bytes big */
 #define BUFSIZE (0x1000 - 2 * sizeof(uint32_t))

--- a/components/VM_Arm/src/modules/virtio_net_arping.c
+++ b/components/VM_Arm/src/modules/virtio_net_arping.c
@@ -8,7 +8,6 @@
 #include <stdint.h>
 #include <string.h>
 #include <autoconf.h>
-#include <arm_vm/gen_config.h>
 #include <vmlinux.h>
 
 #include <camkes.h>
@@ -29,9 +28,6 @@
 #define ARP_REQUEST 0x01
 #define ARP_REPLY 0x02
 #define HW_TYPE 1
-
-extern vmm_pci_space_t *pci;
-extern vmm_io_port_list_t *io_ports;
 
 void self_mac(uint8_t *mac)
 {

--- a/components/VM_Arm/src/modules/virtio_net_virtqueue.c
+++ b/components/VM_Arm/src/modules/virtio_net_virtqueue.c
@@ -8,7 +8,6 @@
 #include <stdint.h>
 #include <string.h>
 #include <autoconf.h>
-#include <arm_vm/gen_config.h>
 #include <vmlinux.h>
 #include <netinet/ether.h>
 
@@ -21,9 +20,6 @@
 
 static virtio_net_t *virtio_net = NULL;
 static vswitch_t virtio_vswitch;
-
-extern vmm_pci_space_t *pci;
-extern vmm_io_port_list_t *io_ports;
 
 void self_mac(uint8_t *mac)
 {


### PR DESCRIPTION
Solving the current corruption problem in `tii-sel4-vm/src/fdt.c`, we really need a module dependency mechanism. We could hardcode the call to creating device tree entries to some CAmkES-VM module, but if we want to support static + dynamic entries too (like in cross-connector code), DT stuff should really be a separate module. Hence this addition.